### PR TITLE
feat(arrconf): add Phase 2 mini-chart with arrconfDryRun=true (PR1)

### DIFF
--- a/argocd/argocd-apps/arrconf-app.yaml
+++ b/argocd/argocd-apps/arrconf-app.yaml
@@ -1,0 +1,23 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: arrconf
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: selfhost
+    server: https://kubernetes.default.svc
+  project: selfhost-project
+  source:
+    repoURL: https://github.com/tom333/my-kluster.git
+    targetRevision: HEAD
+    path: charts/arrconf
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/charts/arrconf/Chart.yaml
+++ b/charts/arrconf/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: arrconf
+description: "arrconf — config-as-code reconciler for Sonarr/Radarr/Prowlarr/qBit/Seerr (Phase 2 scope: Sonarr download_clients only)"
+type: application
+version: 0.1.2
+appVersion: "0.1.2"

--- a/charts/arrconf/README.md
+++ b/charts/arrconf/README.md
@@ -1,0 +1,76 @@
+# charts/arrconf
+
+Mini-chart custom (D-24, Phase 2 scope) qui déploie le CronJob `arrconf` dans le namespace `selfhost` pour réconcilier la config Sonarr depuis YAML (config-as-code, ADR-1).
+
+> **Scope Phase 2** : Sonarr `download_clients` uniquement (D-25). Phase 3 étendra à indexers / notifications / root_folders / tags / host_config + Radarr + Prowlarr. Phase 4 absorbera ce mini-chart dans l'umbrella `charts/arr-stack/`.
+
+## Two-PR protocol (D-28)
+
+Pour valider sans risque qu'arrconf ne corrompe pas la config Sonarr en production, le déploiement passe par **deux PRs séquentielles** :
+
+| PR | Change | `arrconfDryRun` | Comportement | Critère succès |
+|---|---|---|---|---|
+| **PR1** | création complète chart + ArgoCD App + Secret | `true` (default) | log les actions sans appeler `POST/PUT/DELETE` | `diff -rq snapshots/before-phase-2-<date>/sonarr/ snapshots/post-phase2-pr1-<date>/sonarr/` = 0 |
+| **PR2** | one-line `values.yaml`: `arrconfDryRun: true` → `false` | `false` | apply réel | `sonarr/tag.json` gagne entrée `arrconf-managed`; download_client managé visible dans Sonarr UI |
+
+PR1 doit être mergée et la phase de dry-run validée AVANT d'ouvrir PR2.
+
+## Pre-merge checklist (PR1)
+
+Avant de merger PR1, vérifier dans l'ordre :
+
+1. **Secret bootstrap appliqué manuellement** — ArgoCD ne synchronise pas `secrets/` (exclu du sync) :
+   ```bash
+   kubectl apply -f my-kluster/secrets/arrconf-secret.yaml
+   kubectl get secret arrconf-env -n selfhost   # expect: present
+   ```
+   Si oublié : Pod CrashLoops sur `SONARR_API_KEY` manquant.
+
+2. **Image GHCR publique et pullable** (Phase 1 HUMAN-UAT #1, ADR-3) :
+   ```bash
+   docker logout ghcr.io
+   docker pull ghcr.io/tom333/arr-stack-arrconf:0.1.2
+   ```
+   Si fail : toggle visibility dans GitHub package settings (Danger Zone → Public).
+
+3. **Snapshot baseline pré-déploiement existe** (ADR-6) :
+   ```bash
+   ls /home/moi/projets/perso/arr-stack/snapshots/before-phase-2-2026-05-08/sonarr/downloadclient.json
+   ```
+
+## Drift demo runbook (post-PR2)
+
+Pour prouver REQ-drift-detection après merge PR2 :
+
+```bash
+# 1. Forensic snapshot AVANT le test (W-01 REQUIRED)
+tools/snapshot/snapshot.sh --apps sonarr --output snapshots/drift-test-$(date +%F)/
+
+# 2. Mutation UI hors-Git (port-forward + curl ou UI)
+kubectl -n selfhost port-forward svc/sonarr 8989:8989 &
+# Modifier name du download_client en UI ou via API
+
+# 3. Forcer un Job arrconf hors-cron pour observer la correction immédiate :
+kubectl -n selfhost create job --from=cronjob/arrconf arrconf-drift-demo
+kubectl -n selfhost logs job/arrconf-drift-demo > .planning/phases/02-arrconf-cluster-validation/evidence/drift-demo-$(date +%F).log
+
+# 4. Vérifier dispositive value-equality (W-04) :
+grep -E '"event":"plan_action".*"action":"update"' .planning/.../drift-demo-*.log
+# Le log doit contenir au moins 1 update event indiquant que la mutation UI est revertée.
+```
+
+## Operational caveats (Pitfalls)
+
+- **`concurrencyPolicy: Forbid`** ne bloque QUE les Jobs créés par le scheduler (Pitfall 4). Un Job `kubectl create job --from=cronjob/arrconf` est autorisé même si une instance schedulée tourne — utile pour le drift demo, attention en run normal.
+- **`selfHeal: true`** dans ArgoCD ⇒ `kubectl edit cronjob arrconf` est revert au prochain sync (Pitfall 8). Pour modifier en prod : passer par PR sur ce chart.
+- **`checksum/config` annotation** : largement cosmétique (Pitfall 5). Pour qu'un nouveau ConfigMap force un nouveau Pod hash, il faut hash `subPath` correctement — l'implémentation actuelle re-crée le hash mais Kubernetes ne re-pull pas le ConfigMap dans un volume `subPath` mid-Pod. Pour forcer un redeploy : `kubectl rollout restart cronjob/arrconf` (ou suspendre/réactiver).
+- **`tty: true` retiré** (Pitfall 10) : structlog active le rendering JSON quand stdout n'est pas un TTY. Avec `tty: true` les logs étaient en console-friendly format, illisibles par jq. Sans tty:true → JSON propre, parsable.
+
+## Frontière configarr (ADR-5)
+
+Ce chart **ne** réconcilie **pas** :
+- `quality_profiles`, `custom_formats`, `quality_definitions`, `media_naming` ← propriété de `charts/configarr/` (ScopeViolationError côté arrconf si config tentait d'écrire ces endpoints)
+
+## Renovate
+
+L'image `ghcr.io/tom333/arr-stack-arrconf` est suivie via l'annotation `# renovate: image=...` dans `values.yaml` (ligne au-dessus de `repository:`, sans ligne vide). Bump auto sur les tags semver `vX.Y.Z` du repo arr-stack.

--- a/charts/arrconf/files/arrconf.yml
+++ b/charts/arrconf/files/arrconf.yml
@@ -1,0 +1,45 @@
+apps:
+  sonarr:
+    main:
+      base_url: http://sonarr.selfhost.svc.cluster.local:8989
+      download_clients:
+        prune: false
+        items:
+          - name: qBittorrent
+            enable: true
+            protocol: torrent
+            priority: 1
+            implementation: QBittorrent
+            configContract: QBittorrentSettings
+            fields:
+              - name: host
+                value: qbittorrent.selfhost.svc.cluster.local
+              - name: port
+                value: 8080
+              - name: useSsl
+                value: false
+              - name: urlBase
+                value: ''
+              - name: username
+                value: ''
+              - name: password
+                value: ''
+              - name: tvCategory
+                value: sonarr
+              - name: tvImportedCategory
+                value: ''
+              - name: recentTvPriority
+                value: 0
+              - name: olderTvPriority
+                value: 0
+              - name: initialState
+                value: 0
+              - name: sequentialOrder
+                value: false
+              - name: firstAndLast
+                value: false
+              - name: contentLayout
+                value: 0
+            tags: []
+            removeCompletedDownloads: true
+            removeFailedDownloads: true

--- a/charts/arrconf/templates/_helpers.tpl
+++ b/charts/arrconf/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "arrconf.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "arrconf.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name + version label.
+*/}}
+{{- define "arrconf.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "arrconf.labels" -}}
+helm.sh/chart: {{ include "arrconf.chart" . }}
+{{ include "arrconf.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "arrconf.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "arrconf.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/arrconf/templates/configmap.yaml
+++ b/charts/arrconf/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "arrconf.fullname" . }}
+  labels:
+    {{- include "arrconf.labels" . | nindent 4 }}
+data:
+  arrconf.yml: |-
+{{ .Files.Get "files/arrconf.yml" | indent 4 }}

--- a/charts/arrconf/templates/cronjob.yaml
+++ b/charts/arrconf/templates/cronjob.yaml
@@ -1,0 +1,49 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "arrconf.fullname" . }}
+  labels:
+    {{- include "arrconf.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.failedJobsHistoryLimit }}
+  startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds | default 600 }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "arrconf.selectorLabels" . | nindent 12 }}
+          annotations:
+            checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          containers:
+            - name: arrconf
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              args: ["apply", "--config", "/app/config/arrconf.yml", "--apps", "sonarr"]
+              env:
+                - name: TZ
+                  value: {{ .Values.timezone | quote }}
+                - name: ARRCONF_DRY_RUN
+                  value: {{ .Values.arrconfDryRun | quote }}
+              envFrom:
+                - secretRef:
+                    name: {{ .Values.apiKeysSecret }}
+              volumeMounts:
+                - name: config
+                  mountPath: /app/config/arrconf.yml
+                  subPath: arrconf.yml
+              resources:
+                {{- toYaml .Values.resources | nindent 16 }}
+          volumes:
+            - name: config
+              configMap:
+                name: {{ include "arrconf.fullname" . }}

--- a/charts/arrconf/values.yaml
+++ b/charts/arrconf/values.yaml
@@ -1,0 +1,29 @@
+image:
+  # renovate: image=ghcr.io/tom333/arr-stack-arrconf
+  repository: ghcr.io/tom333/arr-stack-arrconf
+  tag: "0.1.2"
+  pullPolicy: IfNotPresent
+
+schedule: "0 */4 * * *"
+timezone: "Europe/Paris"
+startingDeadlineSeconds: 600
+
+# Two-PR dry-run protocol (D-28):
+#   PR1: arrconfDryRun: true   -> observe logs, prove zero writes
+#   PR2: arrconfDryRun: false  -> enable apply
+arrconfDryRun: true
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 50m
+    memory: 128Mi
+
+# Manual bootstrap secret (D-29):
+#   kubectl apply -f my-kluster/secrets/arrconf-secret.yaml BEFORE merging PR1
+apiKeysSecret: arrconf-env
+
+successfulJobsHistoryLimit: 1
+failedJobsHistoryLimit: 2


### PR DESCRIPTION
Phase 2 PR1 of two-PR protocol (D-28 in arr-stack).
- Mini-chart mirrors charts/configarr/ (D-24); replaced by arr-stack umbrella in Phase 4.
- arrconfDryRun: true — observe one cron cycle, prove zero writes, then PR2 flips to false.
- Bootstrap secret arrconf-env (SONARR_API_KEY only — D-29) is gitignored; applied manually with `kubectl apply -f secrets/arrconf-secret.yaml` BEFORE this PR merges.
- ArgoCD App in selfhost-project, automated selfHeal+prune (mirror configarr-app.yaml).

Pre-merge requirements (already done):
- kubectl apply -f secrets/arrconf-secret.yaml (Pitfall 3)
- GHCR package visibility = Public (Pitfall 1, resolved Phase 1 HUMAN-UAT #1)
- Image tag 0.1.2 verified pullable anonymously (Pitfall 2)

Refs: arr-stack/.planning/phases/02-arrconf-cluster-validation/02-CONTEXT.md