### PR TITLE
fix(arrconf): cronjob args — --config goes BEFORE 'apply' subcommand

### DIFF
--- a/charts/arrconf/templates/cronjob.yaml
+++ b/charts/arrconf/templates/cronjob.yaml
@@ -28,7 +28,7 @@ spec:
             - name: arrconf
               image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
-              args: ["apply", "--config", "/app/config/arrconf.yml", "--apps", "sonarr"]
+              args: ["--config", "/app/config/arrconf.yml", "apply", "--apps", "sonarr"]
               env:
                 - name: TZ
                   value: {{ .Values.timezone | quote }}


### PR DESCRIPTION
## Summary

PR1 (#1366) deployed cleanly but the first smoke job CrashLooped:
\`\`\`
Usage: arrconf apply [OPTIONS]
Error: No such option: --config
\`\`\`

## Root cause

The arrconf CLI structure is \`arrconf [OPTIONS] COMMAND [ARGS]...\`. \`--config\` is a top-level option (default \`/etc/arrconf/arrconf.yml\`), not an \`apply\` subcommand option.

Old (broken):
\`\`\`yaml
args: ["apply", "--config", "/app/config/arrconf.yml", "--apps", "sonarr"]
\`\`\`

New (working):
\`\`\`yaml
args: ["--config", "/app/config/arrconf.yml", "apply", "--apps", "sonarr"]
\`\`\`

VolumeMount path stays \`/app/config/arrconf.yml\` per Plan 02-03 PATTERNS.md §5 substitution map.

## Test plan

After merge:
- ArgoCD syncs the updated cronjob template
- \`kubectl create job --from=cronjob/arrconf arrconf-pr1-smoke-retry -n selfhost\`
- Job completes with arrconf logging dry-run path events (W-06)