### PR TITLE
feat(arrconf): Phase 2.1 PR3 — bump image to 0.1.3 + drop placeholder credentials

### DIFF
--- a/charts/arrconf/files/arrconf.yml
+++ b/charts/arrconf/files/arrconf.yml
@@ -20,10 +20,6 @@ apps:
                 value: false
               - name: urlBase
                 value: ''
-              - name: username
-                value: ''
-              - name: password
-                value: ''
               - name: tvCategory
                 value: sonarr
               - name: tvImportedCategory

--- a/charts/arrconf/values.yaml
+++ b/charts/arrconf/values.yaml
@@ -1,7 +1,7 @@
 image:
   # renovate: image=ghcr.io/tom333/arr-stack-arrconf
   repository: ghcr.io/tom333/arr-stack-arrconf
-  tag: "0.1.2"
+  tag: "0.1.3"
   pullPolicy: IfNotPresent
 
 schedule: "0 */4 * * *"


### PR DESCRIPTION
## Summary
- Bumps arrconf image: `0.1.2` → `0.1.3` (arr-stack release v0.1.3, GHCR public)
- Removes `username: ''` and `password: ''` placeholder entries from qBit fields[] in arrconf.yml (D-36)

## Why
arr-stack v0.1.3 introduces `merge_fields_for_put()` (D-31/D-32/D-33). With the
merge helper, any FieldKV whose YAML value is `''` is preserved from the cluster
state at PUT time. This eliminates the Phase 2 PR2 PUT 400 root cause (Sonarr
rejected the body because qBit credentials were overwritten with empties).

The placeholder entries become redundant under the new contract — D-36 removes
them so the YAML reflects "arrconf does not manage these fields" cleanly.

## Validation
- arr-stack CI green on Wave 2 (ruff/mypy/pytest --cov-fail-under=70)
- `test_round_trip_with_redacted_credentials_is_noop` proves dump+merge contract composes
- arr-stack v0.1.3 image anonymously pullable from GHCR (digest sha256:980bf352…99a87)

## Post-merge plan
1. ArgoCD self-heal applies the new image + ConfigMap (~3 min)
2. Force smoke job: `kubectl create job --from=cronjob/arrconf arrconf-pr3-smoke-$(date +%s) -n selfhost`
3. Expect: `merge_field_preserved` events for username/password + PUT 200 on /downloadclient/1
4. arr-stack Plan 02.1-04 re-runs Plan 02-05 Tasks 5.1c + 5.2 for Phase 2 closure