### PR TITLE
fix(arrconf): Phase 2.1 PR4 hotfix — re-add username/password placeholders

### DIFF
--- a/charts/arrconf/files/arrconf.yml
+++ b/charts/arrconf/files/arrconf.yml
@@ -20,6 +20,10 @@ apps:
                 value: false
               - name: urlBase
                 value: ''
+              - name: username
+                value: ''
+              - name: password
+                value: ''
               - name: tvCategory
                 value: sonarr
               - name: tvImportedCategory


### PR DESCRIPTION
## Summary

Hotfix for the regression introduced by PR #1369 (Phase 2.1 PR3, D-36).

PR3 removed the `username: ''` and `password: ''` placeholder entries from `charts/arrconf/files/arrconf.yml` under the assumption that arrconf v0.1.3's `merge_fields_for_put` helper would protect those fields. The helper does protect empty-value entries when they are **present** in YAML, but it does **not** backfill entries that are **missing** from YAML.

## What broke

The first post-PR3 smoke job (`arrconf-pr3-smoke-1778276064`) ran in apply mode under `ghcr.io/tom333/arr-stack-arrconf:0.1.3` and successfully attached the `arrconf-managed` tag (`tags: [1]`). However, the same `PUT /api/v3/downloadclient/1` body was missing the `username` and `password` field entries — so Sonarr cleared them.

Verification (post-smoke API GET on Sonarr's qBit downloadclient):

```
"username": { "value": null }
"password": { "value": null }
```

qBit `AuthSubnetWhitelist=192.168.88.0/24` does not cover the cluster pod network → Sonarr can no longer auth to qBit → torrent additions will fail.

## What this PR fixes

Re-adds the 4-line placeholder block to `arrconf.yml`. The next arrconf run will:

1. See `username: ''` and `password: ''` in the desired body.
2. Fire `merge_field_preserved` for both fields (helper substitutes cluster value).
3. PUT body carries the cluster's stored values → Sonarr keeps them.

## Operator action required after merge

1. Wait for ArgoCD to sync the new ConfigMap.
2. Re-enter qBit username + password in Sonarr UI: **Settings → Download Clients → qBittorrent → save**. (The values were cleared by the PR3 PUT and must be restored before the CronJob can preserve them.)
3. Unsuspend the CronJob: `kubectl patch cronjob arrconf -n selfhost -p '{"spec":{"suspend":false}}'` — it was suspended at the start of this hotfix window.
4. Force a smoke job: `kubectl create job --from=cronjob/arrconf arrconf-pr4-smoke-$(date +%s) -n selfhost` — expected: ≥2 `merge_field_preserved` events (one for username, one for password) AND `username`/`password` remain `<set>` on Sonarr's GET after the run.

## Why not a code fix

A "true" fix would enhance `merge_fields_for_put` to also backfill cluster fields missing from desired (a separate Phase 2.1 amendment, would require a v0.1.4 release). For now, sticking with the helper's existing contract is the smallest, safest change. The Phase 2.1 RETRO will document this and recommend whether to enhance the helper in Phase 3 (Radarr/Prowlarr will face the same shape).

## CronJob currently suspended

`kubectl get cronjob arrconf -n selfhost -o jsonpath='{.spec.suspend}'` → `true` (suspended at the start of the hotfix window to prevent the running cron from re-clearing fields between credential restoration and ArgoCD reconcile).