### PR TITLE
feat(arrconf): bump image v0.1.3 -> v0.1.4 (forceSave fix)

### DIFF
--- a/charts/arrconf/values.yaml
+++ b/charts/arrconf/values.yaml
@@ -1,7 +1,7 @@
 image:
   # renovate: image=ghcr.io/tom333/arr-stack-arrconf
   repository: ghcr.io/tom333/arr-stack-arrconf
-  tag: "0.1.3"
+  tag: "0.1.4"
   pullPolicy: IfNotPresent
 
 schedule: "0 */4 * * *"


### PR DESCRIPTION
## Summary

Atomic image-tag bump only. Closes D-02.1-06 (forceSave fix).

- `charts/arrconf/values.yaml`: `tag: "0.1.3"` → `tag: "0.1.4"`
- `charts/arrconf/files/arrconf.yml`: **UNCHANGED** (placeholders stay per Phase 2.1 PR4)
- `charts/arrconf/templates/cronjob.yaml`: **UNCHANGED**

## Why

Sonarr's GET /api/v3/downloadclient/{id} masks `privacy=password` fields with the literal `********`. Phase 2.1's `merge_fields_for_put` faithfully preserves this mask in the PUT body. Sonarr's pre-save validation re-authenticates against `********` and rejects the PUT with HTTP 400 on any real-change PUT (e.g. priority drift). v0.1.4 ships `?forceSave=true` on UPDATE PUTs — arrconf is the trusted controller per ADR-8.

Required prerequisite before Phase 3 (Radarr/Prowlarr automated drift correction would face the identical 400 failure mode).

## Test plan

- [ ] CronJob suspended pre-merge (already done by operator workflow)
- [ ] After merge: ArgoCD self-heals; live CronJob shows `image: ghcr.io/tom333/arr-stack-arrconf:0.1.4`
- [ ] CronJob unsuspended after ArgoCD sync OK
- [ ] Forced smoke job (next phase) shows: `put_force_save_used` event + `plan_action action=update` + PUT 200 (no more 400)
- [ ] Drift demo runbook re-executed WITHOUT operator manual `?forceSave=true` nudge — closes REQ-drift-detection cleanly

See arr-stack `.planning/phases/02.2-v0-1-4-forcesave-fix/` for full phase context.