### PR TITLE
chore(arr-stack): bump targetRevision v0.2.2 -> v0.2.3 (Helm 4 vendor fix)

### DIFF
--- a/argocd/argocd-apps/arr-stack-app.yaml
+++ b/argocd/argocd-apps/arr-stack-app.yaml
@@ -12,7 +12,7 @@ spec:
     namespace: selfhost
   source:
     repoURL: https://github.com/tom333/arr-stack.git
-    targetRevision: v0.2.2
+    targetRevision: v0.2.3
     path: charts/arr-stack
     helm:
       valueFiles:


### PR DESCRIPTION
One-line bump from v0.2.2 to v0.2.3 to unblock the arr-stack cutover.

v0.2.2 failed ArgoCD render with Helm 4 multi-alias regression. v0.2.3 vendors the unpacked app-template chart directory (see [arr-stack PR #2](https://github.com/tom333/arr-stack/pull/2), merged 5bc0b0d).

Once merged, operator will:
1. Manual-sync 'applications' parent App so it picks up the new arr-stack-app.yaml
2. Manual-sync 'arr-stack' App with Replace=true → adopts the 8 Deployments + 7 Ingresses + 2 CronJobs currently orphaned in selfhost from the v0.2.2 cutover attempt