### PR TITLE
chore(arr-stack): bump targetRevision v0.2.4 -> v0.2.5

### DIFF
--- a/argocd/argocd-apps/arr-stack-app.yaml
+++ b/argocd/argocd-apps/arr-stack-app.yaml
@@ -12,7 +12,7 @@ spec:
     namespace: selfhost
   source:
     repoURL: https://github.com/tom333/arr-stack.git
-    targetRevision: v0.2.4
+    targetRevision: v0.2.5
     path: charts/arr-stack
     helm:
       valueFiles:


### PR DESCRIPTION
Picks up arr-stack PR #4: re-syncs examples/values-prod.yaml to canonical values.yaml (cleanuparr 2.9.6 fix wasn't taking effect because ArgoCD loads values-prod.yaml, not values.yaml).