### PR TITLE
chore(arr-stack): bump targetRevision v0.2.5 -> v0.2.6 (per-alias nameOverride + SA)

### DIFF
--- a/argocd/argocd-apps/arr-stack-app.yaml
+++ b/argocd/argocd-apps/arr-stack-app.yaml
@@ -12,7 +12,7 @@ spec:
     namespace: selfhost
   source:
     repoURL: https://github.com/tom333/arr-stack.git
-    targetRevision: v0.2.5
+    targetRevision: v0.2.6
     path: charts/arr-stack
     helm:
       valueFiles:


### PR DESCRIPTION
Picks up arr-stack PR #5: closes Phase 4 cutover postmortem Bug 1 (Service selector too broad — internal traffic misroute) and Bug 2 (serviceAccountName mismatch — manual SA workaround).