### PR TITLE
chore(arr-stack): bump targetRevision v0.2.6 -> v0.2.7 (arrconf schema fix)

### DIFF
--- a/argocd/argocd-apps/arr-stack-app.yaml
+++ b/argocd/argocd-apps/arr-stack-app.yaml
@@ -12,7 +12,7 @@ spec:
     namespace: selfhost
   source:
     repoURL: https://github.com/tom333/arr-stack.git
-    targetRevision: v0.2.6
+    targetRevision: v0.2.7
     path: charts/arr-stack
     helm:
       valueFiles:


### PR DESCRIPTION
Picks up arr-stack PR #6: flattens charts/arr-stack/files/arrconf.yml to match the v0.2.1 binary's RootConfig schema (drops apps: wrapper).