### PR TITLE
chore(arr-stack): bump targetRevision v0.2.7 -> v0.2.8 (Bug 5 symlink hardening)

### DIFF
--- a/argocd/argocd-apps/arr-stack-app.yaml
+++ b/argocd/argocd-apps/arr-stack-app.yaml
@@ -12,7 +12,7 @@ spec:
     namespace: selfhost
   source:
     repoURL: https://github.com/tom333/arr-stack.git
-    targetRevision: v0.2.7
+    targetRevision: v0.2.8
     path: charts/arr-stack
     helm:
       valueFiles:


### PR DESCRIPTION
Picks up arr-stack PR #7: replaces examples/values-prod.yaml file-copy with symlink to canonical values.yaml. Closes Bug 5 from Phase 4 cutover postmortem.