### PR TITLE
fix(arr-stack): ignore PVC volumeName + storageClassName on sync

### DIFF
--- a/argocd/argocd-apps/arr-stack-app.yaml
+++ b/argocd/argocd-apps/arr-stack-app.yaml
@@ -25,3 +25,16 @@ spec:
     automated:
       prune: true
       selfHeal: true
+  # K8s populates spec.volumeName + spec.storageClassName on PVCs after binding, then locks them
+  # as immutable. Helm renders without these fields (provisioner assigns at bind time), so
+  # Replace=true above tries to remove them on every sync → "spec is immutable" retry storm
+  # across all 7 bjw-s/app-template PVCs (cleanuparr, jellyfin, prowlarr, qbittorrent, radarr,
+  # seerr, sonarr). selfHeal eventually grinds past it but produces noisy attempt-N failures
+  # in the Argo UI. Narrow ignore: only PVCs, only the two auto-bound fields. resources.requests
+  # remains tracked — chart-side size changes still reconcile.
+  ignoreDifferences:
+    - group: ""
+      kind: PersistentVolumeClaim
+      jsonPointers:
+        - /spec/volumeName
+        - /spec/storageClassName


### PR DESCRIPTION
## Summary

Adds `ignoreDifferences` to the arr-stack Argo Application so PVC syncs stop producing "spec is immutable" retry storms.

## Root cause

`syncOptions: Replace=true` applies `kubectl replace` on every resource on every sync. For bound PVCs, K8s makes `spec.volumeName` and `spec.storageClassName` immutable post-bind, but Helm renders PVCs without those fields (populated by the storage provisioner at bind time). The replace tries to remove them → K8s rejects:

```
PersistentVolumeClaim "<name>" is invalid: spec: Forbidden: spec is immutable
after creation except resources.requests and volumeAttributesClassName for
bound claims
```

All 7 `bjw-s/app-template` PVCs hit this on every sync (cleanuparr, jellyfin, prowlarr, qbittorrent, radarr, seerr, sonarr). `selfHeal` grinds past it eventually but the noise floods the UI on every chart change. Observed twice in the past hour during arr-stack Plan 05-08 work (post-PR-#10 sync, post-PR-#12 sync).

## Fix

Narrow scalpel — only PVCs, only the two auto-populated fields. `resources.requests` stays tracked (chart-side size changes still reconcile).

```yaml
ignoreDifferences:
  - group: ""
    kind: PersistentVolumeClaim
    jsonPointers:
      - /spec/volumeName
      - /spec/storageClassName
```

`Replace=true` stays in place — Phase 4 invariant for Deployment-selector immutability at the next umbrella-chart cutover (D-04-CUTOVER-05).

## Test plan

- [ ] CI green
- [ ] After merge: next arr-stack sync no longer logs PVC retry storm
- [ ] arr-stack App stays `Synced` + `Healthy` on subsequent chart changes
- [ ] Functional check: bumping a PVC size in arr-stack values.yaml still triggers a real PVC update (proves `resources.requests` is NOT ignored)