### PR TITLE
fix(arr-stack): drop Replace=true (PVC immutability — ignoreDifferences alone insufficient)

### DIFF
--- a/argocd/argocd-apps/arr-stack-app.yaml
+++ b/argocd/argocd-apps/arr-stack-app.yaml
@@ -21,17 +21,24 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
-      - Replace=true        # MANDATORY: Deployment selector immutability — instance label changes at cutover (RESEARCH §"Standard Stack")
+      # Replace=true was added in Phase 4 for the umbrella cutover (Deployment selector
+      # immutability via the app.kubernetes.io/instance label change). The cutover is done.
+      # Keeping it past that makes every sync run `kubectl replace` on the 7 bjw-s/app-template
+      # PVCs, and K8s rejects the replace because spec.volumeName + spec.storageClassName are
+      # immutable post-bind. PR #1403's `ignoreDifferences` only affects diff computation —
+      # Replace=true bypasses it on the apply side. ServerSideApply alone handles ongoing
+      # reconciliation cleanly via field-level patches that respect immutability. Re-add
+      # Replace=true scoped to specific resources only if a future cutover-style change
+      # needs it.
     automated:
       prune: true
       selfHeal: true
-  # K8s populates spec.volumeName + spec.storageClassName on PVCs after binding, then locks them
-  # as immutable. Helm renders without these fields (provisioner assigns at bind time), so
-  # Replace=true above tries to remove them on every sync → "spec is immutable" retry storm
-  # across all 7 bjw-s/app-template PVCs (cleanuparr, jellyfin, prowlarr, qbittorrent, radarr,
-  # seerr, sonarr). selfHeal eventually grinds past it but produces noisy attempt-N failures
-  # in the Argo UI. Narrow ignore: only PVCs, only the two auto-bound fields. resources.requests
-  # remains tracked — chart-side size changes still reconcile.
+  # K8s populates spec.volumeName + spec.storageClassName on PVCs after binding, then locks
+  # them as immutable. Helm renders without these fields (provisioner assigns at bind time).
+  # ignoreDifferences keeps these PVC fields out of the drift signal (ServerSideApply respects
+  # field ownership and won't touch them anyway, but the explicit ignore prevents false drift
+  # alerts in the Argo UI). resources.requests stays tracked — chart-side size changes still
+  # reconcile.
   ignoreDifferences:
     - group: ""
       kind: PersistentVolumeClaim


### PR DESCRIPTION
## Why

PR #1403 added \`ignoreDifferences\` for PVC \`volumeName\` + \`storageClassName\` but the next sync still failed with the immutability error (operationState.phase=Failed at 10:25:32Z, after #1403 merged at 10:24:51Z).

\`ignoreDifferences\` affects DIFF computation; \`Replace=true\` bypasses it on apply via \`kubectl replace\` (full-spec replace). The replace sends the Helm-rendered manifest which omits \`spec.volumeName\` + \`spec.storageClassName\` → K8s rejects.

## Fix

Drop \`Replace=true\`. \`ServerSideApply\` (kept) uses field-level patches that respect K8s field ownership — never touches fields it doesn't own.

Phase 4 cutover (the original justification for Replace=true) is done. Re-add scoped to specific resources only if a future cutover-style change needs it.

\`ignoreDifferences\` stays as belt-and-suspenders.

## Test plan

- [ ] Merge → Argo re-syncs → App stays Synced+Healthy with no PVC retry storm
- [ ] arr-stack PVC sizes still reconcile if changed in chart values.yaml (functional check)