### PR TITLE
chore(arr-stack): bump targetRevision v0.3.3 -> v0.3.4 (Renovate-substitute)

### DIFF
--- a/argocd/argocd-apps/arr-stack-app.yaml
+++ b/argocd/argocd-apps/arr-stack-app.yaml
@@ -12,7 +12,7 @@ spec:
     namespace: selfhost
   source:
     repoURL: https://github.com/tom333/arr-stack.git
-    targetRevision: v0.3.3
+    targetRevision: v0.3.4
     path: charts/arr-stack
     helm:
       valueFiles:


### PR DESCRIPTION
Manual bump because Renovate hasn't scanned since v0.3.4 was tagged ~15 min ago. v0.3.4 pins `arrconf.tag: 0.3.3` which carries the qBit 5.x compat fix (arr-stack PR #11). Unblocks Plan 05-08 Task 8.2 (qBit reconcile completion).