### PR TITLE
Model swap: gemma-4-12b-coder-fable5-composer2.5-v1 → replace ornith-1.0-9b-mtp (auto-eval)

### DIFF
--- a/charts/localai/values.yaml
+++ b/charts/localai/values.yaml
@@ -433,52 +433,6 @@ modelsConfigs:
       request_timeout_seconds: 120
     pii:
       enabled: true
-
-  # Ornith-1.0-9B (DeepReinforce — base Qwen3.5+Gemma4, RL "scaffold+solution").
-  # 9B dense entraîné agentique : SWE-bench Verified 69.4 / Terminal-Bench 2.1 43.1
-  # (≈ classe 27B) — surclasse Qwen3.5-9B (53.2 / 21.3). Tool-calling natif bien
-  # formé (OpenAI tool_calls) + reasoning <think>, ctx 262K, MIT.
-  # Mesuré RTX 3060 (2026-07-20) : 9.3/12 GB VRAM, 61 tok/s (MTP ~1.5x), tool-call OK.
-  # Variante MTP : décodage spéculatif via draft_model (head séparé), pattern
-  # copié de gemma-4-12b (draft_max=2 optimal). Si OOM : ctx 16384/8192 ou cache q4_0.
-  # Caveat : reasoning consomme des tokens → max_tokens généreux sinon content vide.
-  ornith-1.0-9b-mtp: |
-    name: ornith-1.0-9b-mtp
-    backend: llama-cpp
-    known_usecases:
-      - chat
-    context_size: 32768
-    gpu_layers: 99
-    f16: true
-    flash_attention: true
-    mmap: false
-    cache_type_k: q8_0
-    cache_type_v: q8_0
-    draft_model: mtp-Ornith-1.0-9B-head-Q8_0.gguf
-    parameters:
-      model: Ornith-1.0-9B-MTP-Q4_K_M.gguf
-      temperature: 0.6
-      top_p: 0.95
-      top_k: 20
-    download_files:
-      - filename: Ornith-1.0-9B-MTP-Q4_K_M.gguf
-        uri: https://huggingface.co/protoLabsAI/Ornith-1.0-9B-MTP-GGUF/resolve/main/Ornith-1.0-9B-MTP-Q4_K_M.gguf
-      - filename: mtp-Ornith-1.0-9B-head-Q8_0.gguf
-        uri: https://huggingface.co/protoLabsAI/Ornith-1.0-9B-MTP-GGUF/resolve/main/mtp-head/mtp-Ornith-1.0-9B-head-Q8_0.gguf
-    options:
-      - use_jinja:true
-      - spec_type:draft-mtp
-      - draft_max:2
-    function:
-      automatic_tool_parsing_fallback: true
-      grammar:
-        disable: true
-    template:
-      use_tokenizer_template: true
-    stopwords:
-      - "<|im_end|>"
-      - "<|endoftext|>"
-
   # Black Forest Labs Flux.2 Klein, smaller 4B variant.
   # Chosen over the 9B variants because:
   #  - 4B has a complete Diffusers-format repo (model_index.json + text_encoder/
@@ -494,6 +448,37 @@ modelsConfigs:
   # Invoked via the OpenAI-compatible endpoint:
   #   POST /v1/images/generations
   #   { "model": "flux.2-klein", "prompt": "...", "size": "1024x1024", "n": 1 }
+  gemma-4-12b-coder-fable5-composer2.5-v1: |
+    name: gemma-4-12b-coder-fable5-composer2.5-v1
+    backend: llama-cpp
+    known_usecases: [chat]
+    context_size: 8192
+    gpu_layers: 99
+    f16: true
+    flash_attention: true
+    mmap: true
+    cache_type_k: q8_0
+    cache_type_v: q8_0
+    parameters:
+      model: gemma4-coding-Q4_K_M.gguf
+      temperature: 0.6
+      top_p: 0.95
+      top_k: 20
+    download_files:
+      - filename: gemma4-coding-Q4_K_M.gguf
+        uri: https://huggingface.co/yuxinlu1/gemma-4-12B-coder-fable5-composer2.5-v1-GGUF/resolve/main/gemma4-coding-Q4_K_M.gguf
+    options:
+      - use_jinja:true
+    function:
+      automatic_tool_parsing_fallback: true
+      grammar:
+        disable: true
+    template:
+      use_tokenizer_template: true
+    stopwords:
+      - "<|im_end|>"
+      - "<|endoftext|>"
+
   flux.2-klein: |
     name: flux.2-klein
     backend: diffusers

--- a/scripts/eval-harness/README.md
+++ b/scripts/eval-harness/README.md
@@ -52,3 +52,10 @@ Le PR est le **gate humain** — jamais d'auto-merge.
 - **P3 `promote.sh --candidate <n>`** : gate (overall Δ ≥ marge ET pas de régression tool-call) → si gagnant, PR my-kluster (add candidat + remove incumbent + résumé). `--dry-run`.
 - **P4 `eval-pipeline.sh --name <n> --gguf <url>`** : chaîne stage+éval → gate+PR → notify Telegram → cleanup. `poll-candidates.sh` traite la file `~/.config/brain/model-candidates.queue` (**on-demand** : chaque candidat = 1 restart LocalAI, pas de cron aveugle). Veille → ajoute des candidats à la file (format `name|gguf|[draft]|[ctx]`).
 - **P5 `backend-watch.sh`** : alerte Telegram si nouveau backend cuda12-llama-cpp sur quay (cron pc quotidien). Maj = **manuelle gatée** par le harness (auto-update reporté : risque + backend pas déclaratif git).
+
+## Découverte de candidats (sourcing)
+
+Deux sources **disjointes** alimentent la même file `~/.config/brain/model-candidates.queue` (format `name|gguf-url`) ; le harness reste seul juge, la PR reste le gate.
+
+- **`hf-discover.py`** (cron pc 21:45 UTC) : requête HuggingFace Hub **structurée** via `hf models ls --apps llama.cpp --pipeline-tag text-generation --sort trending_score` (deps `huggingface_hub`, uv PEP723). Filtre **taille réelle du .gguf ≤ 9GB** (lecture Hub avant staging = pas de restart LocalAI gâché sur un modèle trop gros), écarte les quants exotiques (ternaire/2-bit non-mainline CUDA, via tags), dédup vs modèles déployés (`values.yaml`) + file + done. IDs/URLs **réels** (zéro hallucination). `--limit N --max-size-gb F --dry-run`.
+- **veille LLM** (skill `veille-digest`, cron Hermes 21:30) : émet `CANDIDAT: name|gguf|...` en prose ; `auto-eval-cycle.sh` (cron pc 22:00) scrape ces lignes de `state.db` → file. Signal complémentaire (blogs/reddit repèrent un modèle *avant* qu'il trend sur HF).

--- a/scripts/eval-harness/hf-discover.py
+++ b/scripts/eval-harness/hf-discover.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["huggingface_hub>=1.20"]
+# ///
+"""Découverte déterministe de candidats modèles sur HuggingFace (cron pc, en amont
+d'auto-eval-cycle). Remplace le sourcing freeform de la veille par une requête Hub
+structurée : `hf models ls --apps llama.cpp` (backend LocalAI) trié trending, filtré
+taille réelle du .gguf ≤ seuil (fit VRAM 3060 avant staging = pas de restart gâché).
+Les fichiers compagnons (MTP head, draft, LoRA, mmproj) sont écartés (≠ poids).
+Les quants exotiques (ternaire/2-bit) NE sont PAS écartés : Bonsai & co sont des
+cibles de déploiement — si le backend cuda12 ne les charge pas encore, le staging
+échoue et le done-cache les retire (cf. reference_bonsai_deploy_blocked).
+
+Alimente la MÊME file que la veille (`~/.config/brain/model-candidates.queue`,
+format `name|gguf-url`) — le harness reste seul juge, la PR reste le gate.
+Le sourcing HF et le sourcing veille sont complémentaires (signaux disjoints).
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+
+CHAT_ID = "843341688"
+HERE = os.path.dirname(os.path.abspath(__file__))
+VALUES = os.path.join(HERE, "..", "..", "charts", "localai", "values.yaml")
+QUEUE = os.environ.get("MODEL_CANDIDATES_QUEUE",
+                       os.path.expanduser("~/.config/brain/model-candidates.queue"))
+DONE = os.environ.get("MODEL_CANDIDATES_DONE",
+                      os.path.expanduser("~/.cache/model-candidates.done"))
+TOKEN_FILE = os.path.expanduser("~/.config/brain/telegram-bot-token")
+
+# fichiers non-quantifiés : gâchent la VRAM, on préfère toujours un quant
+UNQUANTIZED = re.compile(r"\b(bf16|fp16|f16|fp32|f32)\b", re.I)
+SHARDED = re.compile(r"-\d{5}-of-\d{5}")
+# fichiers compagnons (≠ poids principaux) : head MTP, draft, adapter, projector vision.
+# NB: "mtp"/"draft" seuls sont ambigus (le fichier principal Ornith s'appelle
+# ...-MTP-Q4_K_M.gguf) → on ne cible que les marqueurs sans ambiguïté.
+COMPANION = re.compile(r"(mmproj|projector|[-_.]head[-_.]|[-_.]lora[-_.]|adapter"
+                       r"|control[-_]?vector|[-_.]cvec[-_.]|speculat)", re.I)
+HF_BIN = shutil.which("hf") or os.path.join(os.path.dirname(sys.executable), "hf")
+
+
+def norm(s):
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+def hf_json(args, critical=False):
+    """Appelle `hf <args> --json` et parse. [] si échec (best-effort, cron).
+    critical=True → notifie Telegram (la requête principale cassée ≠ 0 trending :
+    sur cron non-surveillé, une CLI/flag cassé passerait sinon inaperçu)."""
+    try:
+        out = subprocess.run([HF_BIN, *args, "--json"],
+                             capture_output=True, text=True, timeout=120, check=True)
+        return json.loads(out.stdout)
+    except (subprocess.SubprocessError, json.JSONDecodeError, OSError) as e:
+        print(f"WARN hf {' '.join(args)}: {e}", file=sys.stderr)
+        if critical:
+            notify(f"⚠️ hf-discover : requête HF principale échouée ({type(e).__name__}) "
+                   f"— CLI/flag/réseau ? Découverte sautée ce soir.")
+        return []
+
+
+def deployed_names():
+    """Noms des modèles déjà dans values.yaml (dedup — ne pas re-proposer)."""
+    try:
+        with open(VALUES) as f:
+            return [norm(m) for m in re.findall(r"^    name: (.+)$", f.read(), re.M)]
+    except OSError:
+        return []
+
+
+def known_from(path, field=lambda l: l.split("|", 1)[0]):
+    """Noms normalisés déjà présents dans un fichier (file/done cache)."""
+    try:
+        with open(path) as f:
+            return {norm(field(l.strip())) for l in f if l.strip() and not l.startswith("#")}
+    except OSError:
+        return set()
+
+
+def is_dup(core, known):
+    """core déjà connu ? match normalisé bidirectionnel (ornith109b ⊂ ornith109bmtp)."""
+    n = norm(core)
+    if len(n) < 6:
+        return n in known
+    return any(n == k or n in k or k in n for k in known)
+
+
+def pick_gguf(repo_id, max_bytes):
+    """Meilleur .gguf mono-fichier ≤ max_bytes (plus gros quant qui rentre = fidélité max)."""
+    best = None
+    for e in hf_json(["models", "ls", repo_id, "-R"]):
+        path, size = e.get("path", ""), e.get("size")
+        if not path.lower().endswith(".gguf") or not size or size > max_bytes:
+            continue
+        base = path.rsplit("/", 1)[-1]
+        if path.count("/") >= 2:
+            continue  # gguf niché profond = repo-collection/toolkit, pas un modèle unique
+        if SHARDED.search(base) or UNQUANTIZED.search(base) or COMPANION.search(base):
+            continue  # sharded=download_files unique impossible ; non-quant=gâche VRAM ; compagnon≠poids
+        if best is None or size > best[1]:
+            best = (path, size)
+    return best
+
+
+def notify(msg):
+    try:
+        with open(TOKEN_FILE) as f:
+            tok = f.read().strip()
+    except OSError:
+        return
+    if not tok:
+        return
+    data = urllib.parse.urlencode({"chat_id": CHAT_ID, "text": msg}).encode()
+    url = f"https://api.telegram.org/bot{tok}/sendMessage"
+    try:
+        urllib.request.urlopen(urllib.request.Request(url, data=data), timeout=15).read()
+    except OSError:
+        pass
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=25, help="modèles trending à examiner")
+    ap.add_argument("--max-size-gb", type=float, default=9.0, help="taille max du .gguf (VRAM 12GB)")
+    ap.add_argument("--dry-run", action="store_true", help="n'écrit pas la file, affiche seulement")
+    args = ap.parse_args()
+    max_bytes = int(args.max_size_gb * 1e9)
+
+    known = set(deployed_names())
+    known |= known_from(QUEUE)
+    known |= known_from(DONE, field=lambda l: l.split()[1] if len(l.split()) > 1 else l)
+
+    models = hf_json(["models", "ls", "--apps", "llama.cpp",
+                      "--pipeline-tag", "text-generation",
+                      "--sort", "trending_score", "--limit", str(args.limit)],
+                     critical=True)
+    print(f"{len(models)} modèles trending llama.cpp examinés (seuil {args.max_size_gb}GB)")
+
+    added = []
+    for m in models:
+        rid = m.get("id", "")
+        name = re.sub(r"-gguf$", "", rid.split("/")[-1], flags=re.I).lower()
+        if is_dup(name, known):
+            print(f"  skip {rid} (déjà déployé/en file)")
+            continue
+        picked = pick_gguf(rid, max_bytes)
+        if not picked:
+            print(f"  skip {rid} (aucun .gguf mono-fichier quantifié ≤ {args.max_size_gb}GB)")
+            continue
+        path, size = picked
+        url = f"https://huggingface.co/{rid}/resolve/main/{path}"
+        added.append((name, url))
+        known.add(norm(name))
+        print(f"  + {name} ({size/1e9:.1f}GB) {path}")
+
+    if not added:
+        print("aucun nouveau candidat HF.")
+        return
+    if args.dry_run:
+        print(f"[dry-run] {len(added)} candidat(s) NON écrits.")
+        return
+    with open(QUEUE, "a") as f:
+        for name, url in added:
+            f.write(f"{name}|{url}\n")
+    names = " ".join(n for n, _ in added)
+    print(f"{len(added)} candidat(s) ajoutés à {QUEUE}:{' ' + names}")
+    notify(f"🤗 Veille HF : {len(added)} modèle(s) trending en file :{' ' + names}\n"
+           f"Lance l'éval : poll-candidates.sh (chaque candidat = 1 restart LocalAI ~15min).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval-harness/run_eval.py
+++ b/scripts/eval-harness/run_eval.py
@@ -33,7 +33,7 @@ def localai_key() -> str:
     return f.read_text().strip() if f.exists() else ""
 
 
-def chat(model, messages, tools=None, max_tokens=2048, temp=0.0):
+def chat(model, messages, tools=None, max_tokens=2048, temp=0.0, timeout=300):
     body = {"model": model, "messages": messages, "max_tokens": max_tokens, "temperature": temp}
     if tools:
         body["tools"] = tools
@@ -44,7 +44,7 @@ def chat(model, messages, tools=None, max_tokens=2048, temp=0.0):
     req.add_header("Content-Type", "application/json")
     t0 = time.time()
     try:
-        with urllib.request.urlopen(req, timeout=300) as r:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
             d = json.load(r)
     except Exception as e:
         return {"error": str(e)[:200], "latency": time.time() - t0}
@@ -52,6 +52,29 @@ def chat(model, messages, tools=None, max_tokens=2048, temp=0.0):
     msg = d["choices"][0]["message"]
     return {"content": msg.get("content") or "", "tool_calls": msg.get("tool_calls") or [],
             "usage": d.get("usage", {}), "latency": dt, "finish": d["choices"][0].get("finish_reason")}
+
+
+def warmup(model, budget=180):
+    """Health-gate : le modèle génère-t-il des tokens sur une requête triviale ?
+    (cold-load inclus). Évite de griller 300s × N tâches sur un modèle qui ne charge
+    pas (quant/backend incompatible, ex Q2_0 ternaire hors mainline). Liveness =
+    completion_tokens>0 : un modèle reasoning peut mettre ses tokens dans `reasoning`
+    (content vide) tout en étant bien vivant. budget total borné."""
+    deadline = time.time() + budget
+    attempt = 0
+    while time.time() < deadline:
+        attempt += 1
+        left = max(20, int(deadline - time.time()))
+        r = chat(model, [{"role": "user", "content": "Reply with one word: ready"}],
+                 max_tokens=64, timeout=left)
+        alive = not r.get("error") and (r.get("content") or r.get("tool_calls")
+                                        or r.get("usage", {}).get("completion_tokens", 0) > 0)
+        if alive:
+            print(f"warmup OK (essai {attempt}, {r.get('latency', 0):.1f}s)")
+            return True
+        print(f"warmup essai {attempt}: {r.get('error', 'réponse vide')[:80]}")
+        time.sleep(5)  # anti busy-loop sur échec/erreur rapide
+    return False
 
 
 def extract_code(text: str) -> str:
@@ -171,6 +194,17 @@ def main():
     args = ap.parse_args()
 
     print(f"== éval {args.model} ({args.tag}) ==")
+    if not warmup(args.model):
+        print("MODÈLE INJOIGNABLE (warmup échoué) — reject rapide (metrics=0)")
+        metrics = {"coding_pass_rate": 0.0, "toolcall_acc": 0.0, "format_acc": 0.0,
+                   "reasoning_acc": 0.0, "mean_tokps": 0.0, "overall": 0.0, "unreachable": 1}
+        results = {"model": args.model, "tag": args.tag, "metrics": metrics, "unreachable": True}
+        outdir = HERE / "results"
+        outdir.mkdir(exist_ok=True)
+        (outdir / f"{args.model}-{args.tag}.json").write_text(json.dumps(results, indent=2))
+        print(json.dumps(metrics, indent=2))
+        return
+
     coding, tokps = score_coding(args.model, load("coding.jsonl"))
     toolcall = score_toolcall(args.model, load("toolcall.jsonl"))
     fmt = score_format(args.model, load("format.jsonl"))


### PR DESCRIPTION
## Model swap: gemma-4-12b-coder-fable5-composer2.5-v1 → ornith-1.0-9b-mtp

Éval automatique (harness deterministic, exp MLflow `localai-model-eval`). Candidat > courant sur le gate (marge 0.02, pas de régression tool-call).

| métrique | gemma-4-12b-coder-fable5-composer2.5-v1 (candidat) | ornith-1.0-9b-mtp (courant) | Δ |
|---|---|---|---|
| overall | 0.982 | 0.946 | +0.036 |
| coding_pass_rate | 0.929 | 0.786 | +0.143 |
| toolcall_acc | 1.000 | 1.000 | +0.000 |
| format_acc | 1.000 | 1.000 | +0.000 |
| reasoning_acc | 1.000 | 1.000 | +0.000 |
| mean_tokps | 32.236 | 64.942 | -32.707 |

**Généré par le pipeline model-autodeploy (P3). Review + merge manuel requis.**